### PR TITLE
chore(cli): update npm package name to e7h4n-app-template-cli

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@repo/core\"]; this.bin[\"app-cli\"]=\"index.js\"; this.files=[\".\"]'",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"e7h4n-app-template-cli\"; delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@repo/core\"]; this.bin[\"app-cli\"]=\"index.js\"; this.files=[\".\"]'",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Update the published npm package name to `e7h4n-app-template-cli`
- Keep the internal monorepo name as `@repo/cli` for consistency

## Test plan
- [ ] Build the CLI package and verify the dist/package.json has the correct name
- [ ] Test npm publishing workflow

🤖 Generated with [Claude Code](https://claude.ai/code)