### PR TITLE
ci: add docs app to release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
         },
         "turbo/apps/web": {
             "releaseType": "node"
+        },
+        "turbo/apps/docs": {
+            "releaseType": "node"
         }
     },
     "plugins": [

--- a/turbo/apps/docs/CHANGELOG.md
+++ b/turbo/apps/docs/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
## Summary
- Add docs app to Release Please configuration for automated version management
- Create CHANGELOG.md file for the docs app

## Changes
- Added `turbo/apps/docs` entry to `release-please-config.json`
- Created initial `CHANGELOG.md` file following the same format as other apps

## Impact
The docs app will now be included in the automated release workflow, ensuring:
- Consistent versioning across all apps
- Automated changelog generation
- Proper release notes for documentation changes

🤖 Generated with [Claude Code](https://claude.ai/code)