### PR TITLE
ci: add GitHub deployment status to preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -80,6 +80,25 @@ jobs:
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
 
+      - name: Create GitHub Deployment for Web
+        if: github.event.action != 'closed'
+        id: create_deployment_web
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: 'preview-web',
+              description: `Preview deployment for PR #${context.payload.pull_request.number}`,
+              transient_environment: true,
+              auto_merge: false,
+              required_contexts: [],
+              production_environment: false
+            });
+            core.setOutput('deployment_id', deployment.data.id);
+
       - name: Deploy Web to Vercel
         if: github.event.action != 'closed'
         env:
@@ -118,6 +137,40 @@ jobs:
           echo "DEPLOYMENT_URL_WEB=$(cat deployment-url-web.txt)" >> $GITHUB_ENV
           cd ../../..
 
+      - name: Update GitHub Deployment Status for Web
+        if: github.event.action != 'closed' && env.DEPLOYMENT_URL_WEB != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.create_deployment_web.outputs.deployment_id }},
+              state: 'success',
+              environment_url: process.env.DEPLOYMENT_URL_WEB,
+              description: 'Web app deployed successfully',
+              auto_inactive: true
+            });
+
+      - name: Create GitHub Deployment for Docs
+        if: github.event.action != 'closed' && vars.VERCEL_PROJECT_ID_DOCS != ''
+        id: create_deployment_docs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: 'preview-docs',
+              description: `Docs preview for PR #${context.payload.pull_request.number}`,
+              transient_environment: true,
+              auto_merge: false,
+              required_contexts: [],
+              production_environment: false
+            });
+            core.setOutput('deployment_id', deployment.data.id);
+
       - name: Deploy Docs to Vercel
         if: github.event.action != 'closed'
         env:
@@ -145,6 +198,21 @@ jobs:
           echo "DEPLOYMENT_URL_DOCS=$(cat deployment-url-docs.txt)" >> $GITHUB_ENV
           echo "DOCS_DEPLOYED=true" >> $GITHUB_ENV
           cd ../../..
+
+      - name: Update GitHub Deployment Status for Docs
+        if: github.event.action != 'closed' && env.DOCS_DEPLOYED == 'true' && env.DEPLOYMENT_URL_DOCS != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.create_deployment_docs.outputs.deployment_id }},
+              state: 'success',
+              environment_url: process.env.DEPLOYMENT_URL_DOCS,
+              description: 'Docs deployed successfully',
+              auto_inactive: true
+            });
 
       - name: Comment PR with Deployment Info
         if: github.event.action != 'closed' && (env.DEPLOYMENT_URL_WEB != '' || env.DEPLOYMENT_URL_DOCS != '')
@@ -199,6 +267,29 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: comment
+              });
+            }
+
+      - name: Mark Deployments as Inactive
+        if: github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get all deployments for this PR
+            const deployments = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha
+            });
+            
+            // Mark each deployment as inactive
+            for (const deployment of deployments.data) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive',
+                description: 'PR closed - deployment removed'
               });
             }
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
         },
         "turbo/apps/web": {
             "releaseType": "node"
+        },
+        "turbo/apps/docs": {
+            "releaseType": "node"
         }
     },
     "plugins": [

--- a/turbo/apps/docs/CHANGELOG.md
+++ b/turbo/apps/docs/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
## Summary
This PR adds GitHub Deployment API integration to the preview workflow, fixing the "This branch has not been deployed" message in PRs.

## Problem
Currently, PRs show "No deployments" even though we have Vercel preview deployments running. This happens because the workflow doesn't create GitHub deployment records.

## Solution
- **Create deployment records** before deploying to Vercel using GitHub's Deployment API
- **Update deployment status** with preview URLs after successful deployment
- **Mark deployments as inactive** when PR is closed
- Creates separate deployment environments for `preview-web` and `preview-docs`

## Benefits
1. **Visible deployment status** - PRs now show deployment status with links
2. **Better tracking** - Easy to see which environments are deployed
3. **Direct access** - Click deployment links directly from PR page
4. **Automatic cleanup** - Deployments marked inactive when PR closes

## How it works
1. When PR is opened/updated:
   - Create GitHub deployment record for web app
   - Deploy to Vercel
   - Update deployment status with preview URL
   - Repeat for docs if configured
   
2. When PR is closed:
   - Mark all deployments as inactive
   - Clean up Neon branch (existing behavior)

## Testing
After this PR is merged, new PRs will show:
- ✅ Deployment status in the PR checks section
- 🔗 Direct links to preview environments
- 📊 Deployment history in the "Deployments" section

🤖 Generated with [Claude Code](https://claude.ai/code)