### PR TITLE
feat: implement lightweight service container for dependency management

### DIFF
--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  experimental: {
+    instrumentationHook: true,
+  },
+};
 
 export default nextConfig;

--- a/turbo/apps/web/src/app/api/example/route.ts
+++ b/turbo/apps/web/src/app/api/example/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/db";
+import { users } from "@/db/schema/user";
+
+/**
+ * Example API route using the service container
+ */
+export async function GET() {
+  try {
+    // Get database from container (will be automatically initialized)
+    const db = await getDb();
+    
+    // Example query
+    const allUsers = await db.select().from(users);
+    
+    return NextResponse.json({
+      success: true,
+      users: allUsers,
+    });
+  } catch (error) {
+    console.error("Database error:", error);
+    return NextResponse.json(
+      { success: false, error: "Database operation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo/apps/web/src/db/index.ts
+++ b/turbo/apps/web/src/db/index.ts
@@ -1,28 +1,22 @@
-import { drizzle } from "drizzle-orm/node-postgres";
-import { Pool } from "pg";
-import { schema } from "./db";
-import { env } from "../env";
+import { getContainer } from "../lib/container";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type { schema } from "./db";
 
-const connectionString = env.DATABASE_URL;
-
-let db: ReturnType<typeof drizzle<typeof schema>> | null = null;
-let pool: Pool | null = null;
-
-export function getDb() {
-  if (!db) {
-    pool = new Pool({ connectionString });
-    db = drizzle(pool, { schema });
-  }
-
-  return db;
+/**
+ * Get database instance from container
+ * The database will be automatically initialized on first use
+ */
+export async function getDb(): Promise<NodePgDatabase<typeof schema>> {
+  const container = getContainer();
+  return container.get("db");
 }
 
-export async function closeDb() {
-  if (pool) {
-    await pool.end();
-    pool = null;
-    db = null;
-  }
+/**
+ * Close database connection
+ */
+export async function closeDb(): Promise<void> {
+  const container = getContainer();
+  await container.close();
 }
 
-export type Database = ReturnType<typeof getDb>;
+export type Database = NodePgDatabase<typeof schema>;

--- a/turbo/apps/web/src/instrumentation.ts
+++ b/turbo/apps/web/src/instrumentation.ts
@@ -1,0 +1,31 @@
+import { Pool } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { getContainer } from "./lib/container";
+import { schema } from "./db/db";
+import { env } from "./env";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const container = getContainer();
+
+    // Register config service
+    container.register("config", () => ({
+      databaseUrl: env.DATABASE_URL,
+      nodeEnv: (process.env.NODE_ENV || "development") as "development" | "production" | "test",
+    }));
+
+    // Register database pool
+    container.register("pool", async () => {
+      const config = await container.get("config");
+      return new Pool({ connectionString: config.databaseUrl });
+    });
+
+    // Register database service
+    container.register("db", async () => {
+      const pool = await container.get("pool");
+      return drizzle(pool, { schema });
+    });
+
+    console.log("Service container initialized");
+  }
+}

--- a/turbo/apps/web/src/lib/container.ts
+++ b/turbo/apps/web/src/lib/container.ts
@@ -1,0 +1,94 @@
+import type { Pool } from "pg";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+
+interface Services {
+  config: {
+    databaseUrl: string;
+    nodeEnv: "development" | "production" | "test";
+  };
+  pool: Pool;
+  db: NodePgDatabase<any>;
+}
+
+type ServiceFactory<K extends keyof Services> = () => Services[K] | Promise<Services[K]>;
+
+class ServiceContainer {
+  private services: Partial<Services> = {};
+  private factories: Partial<{ [K in keyof Services]: ServiceFactory<K> }> = {};
+  private initializing: Partial<{ [K in keyof Services]: Promise<Services[K]> }> = {};
+
+  register<K extends keyof Services>(
+    name: K,
+    factory: ServiceFactory<K>
+  ): void {
+    this.factories[name] = factory;
+  }
+
+  async get<K extends keyof Services>(name: K): Promise<Services[K]> {
+    // Return cached service if exists
+    if (this.services[name]) {
+      return this.services[name] as Services[K];
+    }
+
+    // Wait for ongoing initialization
+    if (this.initializing[name]) {
+      return this.initializing[name] as Promise<Services[K]>;
+    }
+
+    // Initialize service
+    const factory = this.factories[name];
+    if (!factory) {
+      throw new Error(`Service "${String(name)}" not registered`);
+    }
+
+    // Mark as initializing to prevent race conditions
+    const initPromise = Promise.resolve(factory()).then((service) => {
+      this.services[name] = service;
+      delete this.initializing[name];
+      return service;
+    });
+
+    this.initializing[name] = initPromise as Promise<Services[K]>;
+    return initPromise;
+  }
+
+  has<K extends keyof Services>(name: K): boolean {
+    return name in this.services || name in this.factories;
+  }
+
+  async close(): Promise<void> {
+    // Clean up resources
+    const pool = this.services.pool;
+    if (pool) {
+      await pool.end();
+    }
+    this.services = {};
+    this.initializing = {};
+  }
+}
+
+// Global container with development mode support
+declare global {
+  var __container: ServiceContainer | undefined;
+}
+
+function getContainer(): ServiceContainer {
+  if (process.env.NODE_ENV === "development") {
+    // Use global container in development to survive hot reloads
+    if (!globalThis.__container) {
+      globalThis.__container = new ServiceContainer();
+    }
+    return globalThis.__container;
+  }
+
+  // Production uses module-level singleton
+  if (!container) {
+    container = new ServiceContainer();
+  }
+  return container;
+}
+
+let container: ServiceContainer | undefined;
+
+export { getContainer };
+export type { Services, ServiceContainer };

--- a/turbo/apps/web/src/lib/services.ts
+++ b/turbo/apps/web/src/lib/services.ts
@@ -1,0 +1,42 @@
+import { getContainer } from "./container";
+
+/**
+ * Example of extending the container with additional services
+ * 
+ * Usage:
+ * 1. Add new service types to the Services interface in container.ts
+ * 2. Register the service here
+ * 3. Use getService() to access it
+ */
+
+/**
+ * Generic helper to get any service from the container
+ */
+export async function getService<K extends Parameters<ReturnType<typeof getContainer>["get"]>[0]>(
+  name: K
+): ReturnType<ReturnType<typeof getContainer>["get"]> {
+  const container = getContainer();
+  return container.get(name);
+}
+
+/**
+ * Example: Register a cache service
+ * 
+ * First, add to Services interface in container.ts:
+ * interface Services {
+ *   ...
+ *   cache: CacheService;
+ * }
+ * 
+ * Then register it:
+ * container.register("cache", () => new CacheService());
+ */
+
+/**
+ * Example: Register an email service
+ * 
+ * container.register("email", async () => {
+ *   const config = await container.get("config");
+ *   return new EmailService(config.emailApiKey);
+ * });
+ */


### PR DESCRIPTION
## Summary
Implements a lightweight service container pattern for Next.js to manage singleton services without heavy DI frameworks.

## Changes
- Add type-safe service container with lazy initialization
- Enable Next.js instrumentation hook for container setup  
- Refactor database service to use container pattern
- Support development hot-reload with globalThis caching
- Include usage examples and documentation

## Breaking Changes
- `getDb()` now returns `Promise<Database>` instead of synchronous `Database`
- All database access must now use `await getDb()`

## Test Plan
- [ ] Verify database connections work in development
- [ ] Test hot-reload doesn't create multiple connections
- [ ] Confirm production build works correctly
- [ ] Update existing code to use async `getDb()`

🤖 Generated with [Claude Code](https://claude.ai/code)