### PR TITLE
fix: remove invalid secret condition in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: ./.github/actions/init
 
       - name: Push database schema
-        if: ${{ secrets.DATABASE_URL != '' }}
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: cd turbo/apps/web && pnpm db:push


### PR DESCRIPTION
## Summary
Fix GitHub Actions workflow error by removing invalid secret existence check.

## Problem
The workflow had `if: ${{ secrets.DATABASE_URL != '' }}` which is not valid syntax in GitHub Actions. You cannot check if a secret exists using this condition.

## Solution
Remove the conditional check. The `db:push` command will fail naturally if DATABASE_URL is not set, providing appropriate error messaging.

## Test Plan
- [ ] Workflow syntax is now valid
- [ ] Release workflow will run without syntax errors
- [ ] db:push will fail with clear error if DATABASE_URL is missing

🤖 Generated with [Claude Code](https://claude.ai/code)